### PR TITLE
remove incorrectly copied block

### DIFF
--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -854,13 +854,6 @@ export default class Gradebook extends React.Component {
                     Results appear in the table below.<br />
                     Grade processing may take a few seconds.
                   </p>
-                  <div>
-                    Showing
-                    <span className="font-weight-bold"> {this.props.filteredUsersCount} </span>
-                    of
-                    <span className="font-weight-bold"> {this.props.totalUsersCount} </span>
-                    total learners
-                  </div>
                   <Table
                     data={this.props.bulkManagementHistory.map(this.formatHistoryRow)}
                     hasFixedColumnWidths


### PR DESCRIPTION
@edx/masters-devs 
[EDUCATOR-4629](https://openedx.atlassian.net/browse/EDUCATOR-4629)

On the bulk grades page, removed the "showing X out of Y learners" block copied from the other tab

<img width="1246" alt="Screen Shot 2019-09-09 at 11 15 53 AM" src="https://user-images.githubusercontent.com/1639231/64543472-48191500-d2f3-11e9-9c06-122f6db3f4c9.png">
