### PR TITLE
Gradebook styling issues

### DIFF
--- a/src/components/Gradebook/gradebook.scss
+++ b/src/components/Gradebook/gradebook.scss
@@ -129,7 +129,7 @@
     max-width: 1000px;
 }
 
-.original-filename {
+.wrap-text-in-cell {
     overflow-wrap: break-word;
     word-wrap: break-word;
 }

--- a/src/components/Gradebook/gradebook.scss
+++ b/src/components/Gradebook/gradebook.scss
@@ -119,7 +119,6 @@
 
 .input-percent-label {
     margin-top: 10px;
-    margin-left: -60px;
 }
 
 .mb-85 {

--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -831,16 +831,14 @@ export default class Gradebook extends React.Component {
                 onChange={this.handleMaxAssigGradeChange}
               />
               <span className="input-percent-label">%</span>
-              <div className="d-flex align-items-center">
-                <Button
-                  type="submit"
-                  className="btn-outline-secondary"
-                  name="assignmentGradeMinMax"
-                  disabled={!this.props.selectedAssignment}
-                >
-                  Apply
-                </Button>
-              </div>
+              <Button
+                type="submit"
+                className="btn-outline-secondary"
+                name="assignmentGradeMinMax"
+                disabled={!this.props.selectedAssignment}
+              >
+                Apply
+              </Button>
             </form>
           </div>
         </Collapsible>
@@ -868,7 +866,6 @@ export default class Gradebook extends React.Component {
             <span className="input-percent-label">%</span>
             <Button
               buttonType="outline-secondary"
-              className="align-self-center"
               onClick={this.handleCourseGradeFilterApplyButtonClick}
             >
               Apply

--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -223,6 +223,7 @@ export default class Gradebook extends React.Component {
       unique_id: courseId,
       originalFilename,
       id,
+      user: username,
       ...rest
     } = row;
     const resultsText = [
@@ -241,11 +242,21 @@ export default class Gradebook extends React.Component {
       </a>
     );
     const filename = (
-      <span className="original-filename">
+      <span className="wrap-text-in-cell">
         {originalFilename}
       </span>
     );
-    return { resultsSummary, filename, ...rest };
+    const user = (
+      <span className="wrap-text-in-cell">
+        {username}
+      </span>
+    );
+    return {
+      resultsSummary,
+      filename,
+      user,
+      ...rest,
+    };
   };
 
   updateAssignmentTypes = (assignmentType) => {


### PR DESCRIPTION
JIRA: https://openedx.atlassian.net/browse/EDUCATOR-4622
along with an issue I haven't stuck in our bug spreadsheet (described below)

before
<img width="714" alt="Screen Shot 2019-09-09 at 1 57 53 PM" src="https://user-images.githubusercontent.com/6405097/64638933-c8637700-d3d4-11e9-90e5-74a66089e25d.png">
after
<img width="1408" alt="Screen Shot 2019-09-10 at 2 02 28 PM" src="https://user-images.githubusercontent.com/6405097/64638943-ce595800-d3d4-11e9-9197-6fe6ebdb8574.png">
<img width="701" alt="Screen Shot 2019-09-10 at 2 02 04 PM" src="https://user-images.githubusercontent.com/6405097/64638944-ce595800-d3d4-11e9-9633-cd57e9b544b8.png">

