### PR TITLE
Upgrade gradebook from paragon 4 to 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3103,27 +3103,31 @@
       }
     },
     "@edx/paragon": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-4.4.0.tgz",
-      "integrity": "sha512-8yIw42unKxtOhr3+G19lmI4eKXsxTX9h/+OLbhTfgp8rZ//KMV2mA47UpeyvC3GRLgi16dSkRz1Y0SucJMo7TA==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-7.1.5.tgz",
+      "integrity": "sha512-gTRGWVuIT08TcBHkn3Fme//BtJNaJX+QtosQL4Ea79b1/Na2zAjzEI6ovNjjxnHOcTqGbp1x5adhd9MVedGYvQ==",
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.18",
-        "@fortawesome/free-solid-svg-icons": "^5.8.2",
+        "@fortawesome/fontawesome-svg-core": "^1.2.21",
+        "@fortawesome/free-solid-svg-icons": "^5.10.1",
         "@fortawesome/react-fontawesome": "^0.1.4",
         "airbnb-prop-types": "^2.12.0",
+        "bootstrap": "^4.3.1",
         "classnames": "^2.2.6",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
         "mailto-link": "^1.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^6.1.1",
         "react-transition-group": "^4.0.0",
         "sanitize-html": "^1.20.0"
       },
       "dependencies": {
+        "bootstrap": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+          "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+        },
         "email-prop-type": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/email-prop-type/-/email-prop-type-3.0.0.tgz",
@@ -3131,51 +3135,6 @@
           "requires": {
             "email-validator": "^2.0.4"
           }
-        },
-        "loose-envify": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-          "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-dom": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-          "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-is": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
         },
         "react-responsive": {
           "version": "6.1.2",
@@ -3185,15 +3144,6 @@
             "hyphenate-style-name": "^1.0.0",
             "matchmediaquery": "^0.3.0",
             "prop-types": "^15.6.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.13.6",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-          "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
           }
         }
       }
@@ -7742,7 +7692,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -7922,7 +7872,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -8421,6 +8371,11 @@
       "requires": {
         "cssom": "0.3.x"
       }
+    },
+    "csstype": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
+      "integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -9050,11 +9005,27 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.0.tgz",
+      "integrity": "sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.5.5",
+        "csstype": "^2.6.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+        }
       }
     },
     "dom-serializer": {
@@ -9606,7 +9577,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -23381,20 +23352,20 @@
       }
     },
     "react-transition-group": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
-      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
+          "integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@edx/edx-bootstrap": "^0.4.3",
     "@edx/frontend-auth": "^4.0.0",
     "@edx/frontend-component-footer": "^4.1.5",
-    "@edx/paragon": "^4.2.3",
+    "@edx/paragon": "^7.1.5",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
     "@fortawesome/free-brands-svg-icons": "^5.11.2",
     "@fortawesome/free-solid-svg-icons": "^5.11.2",

--- a/src/App.scss
+++ b/src/App.scss
@@ -5,8 +5,6 @@ $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
 
 $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.0.0 to work
-//@import "~@edx/paragon/src/SearchField/SearchField";
-//@import "~@edx/paragon/src/Collapsible/Collapsible";
 
 @import "~@edx/frontend-component-footer/src/lib/scss/site-footer";
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,12 +1,12 @@
-@import "~@edx/edx-bootstrap/sass/edx/theme";
-@import "~bootstrap/scss/bootstrap";
+
+@import "~@edx/paragon/scss/edx/theme.scss";
 
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome";
 
 $input-focus-box-shadow: $input-box-shadow; // hack to get upgrade to paragon 4.0.0 to work
-@import "~@edx/paragon/src/SearchField/SearchField";
-@import "~@edx/paragon/src/Collapsible/Collapsible";
+//@import "~@edx/paragon/src/SearchField/SearchField";
+//@import "~@edx/paragon/src/Collapsible/Collapsible";
 
 @import "~@edx/frontend-component-footer/src/lib/scss/site-footer";
 

--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -824,7 +824,7 @@ export default class Gradebook extends React.Component {
           </React.Fragment>
         }
       >
-        <Collapsible title="Assignments" isOpen className="filter-group">
+        <Collapsible title="Assignments" isOpen className="filter-group mb-3">
           <div>
             <div className="student-filters">
               <span className="label">
@@ -889,7 +889,7 @@ export default class Gradebook extends React.Component {
             </form>
           </div>
         </Collapsible>
-        <Collapsible title="Overall Grade" isOpen className="filter-group">
+        <Collapsible title="Overall Grade" isOpen className="filter-group mb-3">
           <div className="d-flex justify-content-between align-items-center">
             <InputText
               value={this.state.courseGradeMin}
@@ -919,7 +919,7 @@ export default class Gradebook extends React.Component {
             </Button>
           </div>
         </Collapsible>
-        <Collapsible title="Student Groups" isOpen className="filter-group">
+        <Collapsible title="Student Groups" isOpen className="filter-group mb-3">
           <InputSelect
             name="Tracks"
             aria-label="Tracks"


### PR DESCRIPTION
A minimally-invasive upgrade of paragon from version 4 to 7. I'm happy to say none of the tests broke, and only 1 small UI tweak for spacing's sake. 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16495365/67123882-6a8a3200-f1bf-11e9-894a-80bf75163f69.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/16495365/67123951-8988c400-f1bf-11e9-95ef-0a0fd7de03c9.png">

<img width="967" alt="image" src="https://user-images.githubusercontent.com/16495365/67124029-a91fec80-f1bf-11e9-94cf-a8e6431c352e.png">
