### PR TITLE
fix gradebook table cell spacing

### DIFF
--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -456,7 +456,7 @@ export default class Gradebook extends React.Component {
       );
       const emailHeadingLabel = 'Email*';
 
-      headings = headings.map(heading => ({ label: heading, key: heading, width: 'col' }));
+      headings = headings.map(heading => ({ label: heading, key: heading, width: 'col-1' }));
 
       // replace username heading label to include additional user data
       headings[0].label = userInformationHeadingLabel;


### PR DESCRIPTION
Bug/typo was causing table cells to render at an arbitrary rather than fixed width.

Before: 
![image](https://user-images.githubusercontent.com/5533134/89938673-d3c2b200-dbe4-11ea-8414-03c5cf6302a1.png)

After:
![image](https://user-images.githubusercontent.com/5533134/89938686-db825680-dbe4-11ea-9379-d308504cdc8b.png)

JIRA: https://openedx.atlassian.net/browse/EDUCATOR-4973