### PR TITLE
Remove duplicate labels from assignments filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.16",
+  "version": "1.4.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.16",
+  "version": "1.4.18",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/src/components/Gradebook/Assignments.jsx
+++ b/src/components/Gradebook/Assignments.jsx
@@ -78,9 +78,6 @@ export class Assignments extends React.Component {
       <Collapsible title="Assignments" defaultOpen className="filter-group mb-3">
         <div>
           <div className="student-filters">
-            <span className="label">
-              Assignment Types:
-            </span>
             <InputSelect
               label="Assignment Types"
               name="assignment-types"
@@ -92,9 +89,6 @@ export class Assignments extends React.Component {
             />
           </div>
           <div className="student-filters">
-            <span className="label">
-              Assignment:
-            </span>
             <InputSelect
               label="Assignment"
               name="assignment"
@@ -105,7 +99,6 @@ export class Assignments extends React.Component {
               disabled={this.props.assignmentFilterOptions.length === 0}
             />
           </div>
-          <p>Grade Range (0% - 100%)</p>
           <form className="grade-filter-inputs" onSubmit={this.handleSubmitAssignmentGrade}>
             <div className="percent-group">
               <InputText

--- a/src/components/Gradebook/gradebook.scss
+++ b/src/components/Gradebook/gradebook.scss
@@ -31,12 +31,8 @@
 }
 
 .student-filters{
-    display: flex;
     .label{
         padding-top: 30px;
-    }
-    .form-group{
-        margin-left: 10px;
     }
 }
 .grade-history-header{


### PR DESCRIPTION
**TL;DR -**  Remove `<p>`s acting as duplicate label elements in the "Assignments" filter view in gradebook.

JIRA: [EDUCATOR-5502](https://openedx.atlassian.net/browse/EDUCATOR-5502)

**What changed?**

- Removed the following duplicate labels:
    - "Assignment Types:"
    - "Assignment"
    - "Grade Range (0% - 100%)"
- Removed some styling to allow filters to match across filter types

**Developer Checklist**
- [x] Test suites passing
- [x] Received code-owner approving review
- [x] Bumped version number [package.json](../package.json)

**Testing Instructions**

- Run gradebook, verify labels appear as in screenshots and filtering functionality remains

**Before**
<img width="1091" alt="Screen Shot 2020-12-15 at 12 42 28" src="https://user-images.githubusercontent.com/12944465/105240132-fe714900-5b3a-11eb-8de1-0290b8f19b88.png">

**After**
<img width="1091" alt="Screen Shot 2020-12-15 at 12 43 37" src="https://user-images.githubusercontent.com/12944465/105240189-0204d000-5b3b-11eb-8181-19c0da9c7140.png">

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @edx/masters-devs-gta
