### PR TITLE
fix: typo preventing display of assignment name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/src/components/Gradebook/index.jsx
+++ b/src/components/Gradebook/index.jsx
@@ -252,7 +252,7 @@ export default class Gradebook extends React.Component {
   safeSetState = this.createLimitedSetter(
     'adjustedGradePossible',
     'adjustedGradeValue',
-    'assignmnentName',
+    'assignmentName',
     'modalOpen',
     'reasonForChange',
     'todaysDate',


### PR DESCRIPTION
**TL;DR -** A typo was preventing assignment name from updating correctly

JIRA: [EDUCATOR-5640](https://openedx.atlassian.net/browse/EDUCATOR-5640)

**Developer Checklist**
- [x] Test suites passing
- [x] Received code-owner approving review
- [x] Bumped version number [package.json](../package.json)

**Testing Instructions**

- Running gradebook locally, click on a grade to bring up the edit grade modal.
- The assignment name should be filled in at the top of the modal.

Before:

![Screen Shot 2021-03-22 at 2 04 42 PM](https://user-images.githubusercontent.com/1639231/112037073-bc9f5780-8b17-11eb-96cf-cee2d16926d5.png)

After:

![Screen Shot 2021-03-22 at 2 05 41 PM](https://user-images.githubusercontent.com/1639231/112037084-c032de80-8b17-11eb-9265-7730c02e0ddc.png)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality


FYI: @edx/masters-devs-gta
