### PR TITLE
EDUCATOR-5589: Total Grade should always be a percent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.22",
+  "version": "1.4.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.23",
+  "version": "1.4.24",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/src/components/Gradebook/gradebook.scss
+++ b/src/components/Gradebook/gradebook.scss
@@ -72,7 +72,10 @@
     .student-key {
         font-size: 14px;
     }
-    
+
+    #courseGradeTooltipIcon {
+      float: right;
+    }
 
     .table thead tr {
         min-height: 60px;
@@ -110,6 +113,9 @@
       th:nth-child(2),
       td:nth-child(2) {
         width: 240px;
+      }
+      th:nth-last-of-type(1) {
+        width: 150px;
       }
       th, td {
         width: 120px;

--- a/src/data/constants/grades.js
+++ b/src/data/constants/grades.js
@@ -1,0 +1,5 @@
+const EMAIL_HEADING = 'Email';
+const TOTAL_COURSE_GRADE_HEADING = 'Total Grade (%)';
+const USERNAME_HEADING = 'Username';
+
+export { EMAIL_HEADING, TOTAL_COURSE_GRADE_HEADING, USERNAME_HEADING };

--- a/src/data/selectors/grades.js
+++ b/src/data/selectors/grades.js
@@ -1,5 +1,6 @@
 import { formatDateForDisplay } from '../actions/utils';
 import { getFilters } from './filters';
+import { EMAIL_HEADING, TOTAL_COURSE_GRADE_HEADING, USERNAME_HEADING } from '../constants/grades';
 
 const getRowsProcessed = (data) => {
   const {
@@ -52,13 +53,13 @@ const headingMapper = (category, label = 'All') => {
 
   return (entry) => {
     if (entry) {
-      const results = ['Username', 'Email'];
+      const results = [USERNAME_HEADING, EMAIL_HEADING];
 
       const assignmentHeadings = entry
         .filter(filters[filter])
         .map(s => s.label);
 
-      const totals = ['Total'];
+      const totals = [TOTAL_COURSE_GRADE_HEADING];
 
       return results.concat(assignmentHeadings).concat(totals);
     }


### PR DESCRIPTION
**TL;DR -** Total Grade should always be displayed as a percent, as it is a percent.

JIRA: [EDUCATOR-5589](https://openedx.atlassian.net/browse/EDUCATOR-5589)

**What changed?**

- Total Grade should always be displayed as a percent, as it is a percent.
- Previously we had it out of 100, but that makes it look like somehow the course always has an exact total of 100 points. Let's keep it as always a percent to avoid confusion.
- Refactored the label for the "course grade" column out to a constant
- Re-labeled the column "Total Course Grade"

**Developer Checklist**
- [x] Test suites passing
- [x] @sapanathomas523
- [ ] Ben P 
- [x] Bumped version number [package.json](../package.json)

**Testing Instructions**

Change the setting from "Percentage" to "Absolute and back again. The total course grade column should remain a percent.

![Screen Shot 2021-04-09 at 1 28 34 PM](https://user-images.githubusercontent.com/1639231/114219621-e8547700-9938-11eb-8f83-08492a85997e.png)
![Screen Shot 2021-04-09 at 1 28 25 PM](https://user-images.githubusercontent.com/1639231/114219623-e8ed0d80-9938-11eb-9071-69aab6b360d9.png)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality


FYI: @edx/masters-devs-gta
