### PR TITLE
docs: correct link to bulk grade management

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Jump to:
 For existing documentation see:
 
 - Basic Usage: [Review Learner Grades (read-the-docs)](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/student_progress/course_grades.html#review-learner-grades-on-the-instructor-dashboard)
-- Bulk Grade Management: [Override Learner Subsection Scores in Bulk (read-the-docs)](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/student_progress/course_grades.html#review-learner-grades-on-the-instructor-dashboard)
+- Bulk Grade Management: [Override Learner Subsection Scores in Bulk (read-the-docs)](https://edx.readthedocs.io/projects/edx-partner-course-staff/en/latest/student_progress/course_grades.html#override-learner-subsection-scores-in-bulk)
 
 ## Should I use Gradebook in my course?
 


### PR DESCRIPTION
a.k.a. Override Learner Subsection Scores in Bulk

**TL;DR -** correct link to bulk grade management in README

**What changed?**

- there were two links in the README that went to the same section in the docs. I corrected the 2nd link. 

**Developer Checklist**

n/a for a doc change

**Testing Instructions**

click the link in README.rst

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @edx/masters-devs-gta
