### PR TITLE
Gradebook's csv upload does not clear exist error state on receive data.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/src/data/reducers/grades.js
+++ b/src/data/reducers/grades.js
@@ -136,12 +136,16 @@ const grades = (state = initialState, action) => {
         bulkManagement: rest,
       };
     }
-    case UPLOAD_COMPLETE:
+    case UPLOAD_COMPLETE: {
       return {
         ...state,
         showSpinner: false,
-        bulkManagement: { uploadSuccess: true, ...state.bulkManagement },
+        bulkManagement: {
+          ...state.bulkManagement,
+          uploadSuccess: true,
+        },
       };
+    }
     case UPLOAD_ERR:
       return {
         ...state,


### PR DESCRIPTION
On success and set uploadSuccess to true every time (ordering matter in using spread)

JIRA: [EDUCATOR-5796](https://openedx.atlassian.net/browse/EDUCATOR-5796)

**What changed?**

- remove error message from the state
- reorder the spread use so upload success is always true when the upload csv was successful.

**Developer Checklist**
- [x] Test suites passing. (We are rewriting test suite [EDUCATOR-5780](https://openedx.atlassian.net/browse/EDUCATOR-5780)
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [x] Bumped version number [package.json](../package.json)

**Testing Instructions**

- Unit testing was written in a separate commit [EDUCATOR-5780](https://openedx.atlassian.net/browse/EDUCATOR-5780)

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [x] I've tested the new functionality

FYI: @muselesscreator 