### PR TITLE
fix: bad prop causing bulk mgmt errors to not show

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-app-gradebook",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "description": "edx editable gradebook-ui to manipulate grade overrides on subsections",
   "repository": {
     "type": "git",

--- a/src/components/Gradebook/BulkManagement.jsx
+++ b/src/components/Gradebook/BulkManagement.jsx
@@ -91,7 +91,7 @@ export class BulkManagement extends React.Component {
           <StatusAlert
             alertType="danger"
             dialog={this.props.bulkImportError}
-            isOpen={this.props.bulkImportError}
+            open={!!this.props.bulkImportError}
             dismissible={false}
           />
           <StatusAlert


### PR DESCRIPTION
**TL;DR -** Fix a prop name that was causing error banners not to show for bulk management file uploads.

JIRA: [EDUCATOR-5802](https://openedx.atlassian.net/browse/EDUCATOR-5802)

**What changed?**

- Fixed a prop name

**Developer Checklist**
- [x] Test suites passing
- [x] Documentation and test plan updated, if applicable
- [x] Received code-owner approving review
- [x] Bumped version number [package.json](../package.json)

**Testing Instructions**

1. Go to Gradebook configured for bulk grades management
2. Go to the Bulk Management tab
3. Upload an intentionally malformatted CSV (e.g. [NASA's Exoplanet Archive data](https://exoplanetarchive.ipac.caltech.edu/cgi-bin/TblView/nph-tblView?app=ExoTbls&config=PSCompPars), exported as CSV is incompatible with bulk grades both because it has the wrong schema and because it exceeds our upload size limitation)

Existing behavior:
- Error banner does not show

Corrected behavior:
- Error banner shows reason for upload error: e.g. size limitation

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [ ] I've done a visual code review
- [ ] I've tested the new functionality


FYI: @edx/masters-devs-gta
