### PR TITLE
add reasonable width to grade format button

### DIFF
--- a/src/components/GradesTab/GradesTab.scss
+++ b/src/components/GradesTab/GradesTab.scss
@@ -194,3 +194,7 @@
     overflow-wrap: break-word;
     word-wrap: break-word;
 }
+
+select#ScoreView.form-control {
+  padding-right: 26px;
+}


### PR DESCRIPTION
**TL;DR -** 
Grade format button in Gradebook has too-short width, causing the caret icon to overlay the text.
Added a slight right-padding to fix.

Before:
![image](https://user-images.githubusercontent.com/5533134/123160533-4f63d100-d43c-11eb-922b-4ca7cb8f41ea.png)
After:
![image](https://user-images.githubusercontent.com/5533134/123160885-ba150c80-d43c-11eb-873b-e67c2ad69c9a.png)

JIRA: [AU-30](https://openedx.atlassian.net/browse/AU-30)

**What changed?**

- [ More in depth breakdown of changes ]
- [ Peripheral things that got changed ]
- [ etc... ]

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Testing Instructions**

[ How should a reviewer test this PR? ]

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality


FYI: @edx/masters-devs-gta
