### PR TITLE
fix: add excludedCourseRoles to bulk-grades fetch

### DIFF
--- a/src/data/constants/filters.js
+++ b/src/data/constants/filters.js
@@ -12,6 +12,7 @@ export const filters = StrictDict({
   courseGrade: 'courseGrade',
   courseGradeMax: 'courseGradeMax',
   courseGradeMin: 'courseGradeMin',
+  excludedCourseRoles: 'excludedCourseRoles',
   includeCourseRoleMembers: 'includeCourseRoleMembers',
   track: 'track',
 });

--- a/src/data/selectors/filters.js
+++ b/src/data/selectors/filters.js
@@ -132,6 +132,16 @@ export const selectedAssignmentId = (state) => (simpleSelectors.assignment(state
  */
 export const selectedAssignmentLabel = (state) => (simpleSelectors.assignment(state) || {}).label;
 
+/**
+ * Returns the api value for excludedCourseRoles based on the
+ * internal Bool value for includeCourseRoleMembers.
+ * @param {object} state - redux state
+ * @return {string} - '' if to be included, else 'all'
+ */
+export const excludedCourseRoles = (state) => (
+  simpleSelectors.includeCourseRoleMembers(state) ? '' : 'all'
+);
+
 export default StrictDict({
   ...simpleSelectors,
   isDefault,
@@ -143,5 +153,6 @@ export default StrictDict({
   allFilters,
   areAssignmentGradeFiltersSet,
   chooseRelevantAssignmentData,
+  excludedCourseRoles,
   getAssignmentsFromResultsSubstate,
 });

--- a/src/data/selectors/filters.test.js
+++ b/src/data/selectors/filters.test.js
@@ -139,6 +139,15 @@ describe('filters selectors', () => {
     });
   });
 
+  describe('excludedCourseRoles', () => {
+    it('returns empty string if includeCourseRoleMembers', () => {
+      expect(selectors.excludedCourseRoles({ filters: { includeCourseRoleMembers: true } })).toEqual('');
+    });
+    it('returns "all" string if not includeCourseRoleMembers', () => {
+      expect(selectors.excludedCourseRoles({ filters: { includeCourseRoleMembers: false } })).toEqual('all');
+    });
+  });
+
   describe('selectedAssignmentId', () => {
     it('gets filtered assignment ID when available', () => {
       const assignmentId = selectors.selectedAssignmentId(testState);

--- a/src/data/selectors/index.js
+++ b/src/data/selectors/index.js
@@ -127,10 +127,7 @@ export const getHeadings = (state) => grades.headingMapper(
  * @return {string} - generated grade export url
  */
 export const gradeExportUrl = (state) => (
-  lms.urls.gradeCsvUrl({
-    ...module.lmsApiServiceArgs(state),
-    excludeCourseRoles: filters.includeCourseRoleMembers(state) ? '' : 'all',
-  })
+  lms.urls.gradeCsvUrl(module.lmsApiServiceArgs(state))
 );
 
 /**
@@ -140,9 +137,7 @@ export const gradeExportUrl = (state) => (
  * @return {string} - generated intervention export url
  */
 export const interventionExportUrl = (state) => (
-  lms.urls.interventionExportCsvUrl(
-    module.lmsApiServiceArgs(state),
-  )
+  lms.urls.interventionExportCsvUrl(module.lmsApiServiceArgs(state))
 );
 
 /**
@@ -166,6 +161,7 @@ export const lmsApiServiceArgs = (state) => ({
   ),
   courseGradeMin: grades.formatMinCourseGrade(filters.courseGradeMin(state)),
   courseGradeMax: grades.formatMaxCourseGrade(filters.courseGradeMax(state)),
+  excludedCourseRoles: filters.excludedCourseRoles(state),
 });
 
 /**

--- a/src/data/selectors/index.test.js
+++ b/src/data/selectors/index.test.js
@@ -339,24 +339,11 @@ describe('root selectors', () => {
     afterEach(() => {
       moduleSelectors.lmsApiServiceArgs = lmsApiServiceArgs;
     });
-    describe('without includeCourseRoleMembers filter', () => {
-      it('calls the API service with the right args, excluding all course roles', () => {
-        selectors.filters.includeCourseRoleMembers.mockReturnValue(undefined);
-        expect(selector(testState)).toEqual({
-          gradeCsvUrl: {
-            args: [{ lmsArgs: testState, excludeCourseRoles: 'all' }],
-          },
-        });
-      });
-    });
-    describe('with includeCourseRoleMembers filter', () => {
-      it('calls the API service with the right args, including course roles', () => {
-        selectors.filters.includeCourseRoleMembers.mockReturnValue(true);
-        expect(selector(testState)).toEqual({
-          gradeCsvUrl: {
-            args: [{ lmsArgs: testState, excludeCourseRoles: '' }],
-          },
-        });
+    it('calls the API service with the right args', () => {
+      expect(selector(testState)).toEqual({
+        gradeCsvUrl: {
+          args: [{ lmsArgs: testState }],
+        },
       });
     });
   });
@@ -386,6 +373,7 @@ describe('root selectors', () => {
       selectors.filters.assignmentGradeMin = mockFn('assignmentGradeMin');
       selectors.filters.courseGradeMax = mockFn('courseGradeMax');
       selectors.filters.courseGradeMin = mockFn('courseGradeMin');
+      selectors.filters.excludedCourseRoles = mockFn('excludedCourseRoles');
       selectors.grades.formatMaxAssignmentGrade = mockMetaFn('formatMaxAssignmentGrade');
       selectors.grades.formatMinAssignmentGrade = mockMetaFn('formatMinAssignmentGrade');
       selectors.grades.formatMinCourseGrade = mockFn('formatMinCourseGrade');
@@ -412,6 +400,7 @@ describe('root selectors', () => {
         courseGradeMax: {
           formatMaxCourseGrade: { courseGradeMax: testState },
         },
+        excludedCourseRoles: { excludedCourseRoles: testState },
       });
     });
   });


### PR DESCRIPTION
**TL;DR -** 

reworked some badly-located filter logic that was preventing the excludedCourseRoles key from making it into bulk-grades download.
JIRA: [AU-76](https://openedx.atlassian.net/browse/AU-76)

**Developer Checklist**
- [ ] Test suites passing
- [ ] Documentation and test plan updated, if applicable
- [ ] Received code-owner approving review
- [ ] Bumped version number [package.json](../package.json)

**Testing Instructions**
Load a test with staff members.  download bulk grades both With and Without including course members.  Verify that both have data, and that the staff members are missing from file intended to exclude them.

**Reviewer Checklist**

Collectively, these should be completed by reviewers of this PR:

- [x] I've done a visual code review
- [x] I've tested the new functionality


FYI: @edx/masters-devs-gta
